### PR TITLE
feat: add inventory system with persistence

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { PlayerController } from '../player/playerController.js';
 import { SceneManager } from '../render/sceneManager.js';
 import { Physics } from '../physics/physics.js';
+import { InventoryUI } from '../ui/inventory.js';
 
 export class App {
   constructor(root) {
@@ -22,6 +23,7 @@ export class App {
     this.physics = new Physics();
     this.sceneManager = new SceneManager(this.scene, this.renderer);
     this.player = new PlayerController(this.camera, this.renderer.domElement, this.physics);
+    this.inventoryUI = new InventoryUI();
 
     window.addEventListener('resize', () => {
       this.camera.aspect = window.innerWidth / window.innerHeight;

--- a/src/state/persistence.js
+++ b/src/state/persistence.js
@@ -1,0 +1,48 @@
+const DB_NAME = 'game-db';
+const STORE_NAME = 'state';
+const KEY = 'game';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveState(state) {
+  try {
+    const db = await openDB();
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      store.put(state, KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch (err) {
+    console.error('Failed to save state', err);
+  }
+}
+
+export async function loadState() {
+  try {
+    const db = await openDB();
+    const result = await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.get(KEY);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    });
+    db.close();
+    return result;
+  } catch (err) {
+    console.error('Failed to load state', err);
+    return null;
+  }
+}

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+import { saveState, loadState } from './persistence.js';
+
+export const useStore = create((set, get) => ({
+  inventory: [],
+  isInventoryOpen: false,
+  addItem: (item) => {
+    set((state) => {
+      const inventory = [...state.inventory];
+      const index = inventory.findIndex((i) => i.id === item.id);
+      if (index >= 0) {
+        const existing = inventory[index];
+        const count = existing.count || 1;
+        inventory[index] = { ...existing, count: count + (item.count || 1) };
+      } else {
+        inventory.push({ ...item, count: item.count || 1 });
+      }
+      return { inventory };
+    });
+  },
+  removeItem: (id, amount = 1) => {
+    set((state) => {
+      const inventory = state.inventory.map((i) => ({ ...i }));
+      const index = inventory.findIndex((i) => i.id === id);
+      if (index >= 0) {
+        const item = inventory[index];
+        const count = (item.count || 1) - amount;
+        if (count > 0) {
+          inventory[index] = { ...item, count };
+        } else {
+          inventory.splice(index, 1);
+        }
+      }
+      return { inventory };
+    });
+  },
+  toggleInventory: () => set((state) => ({ isInventoryOpen: !state.isInventoryOpen })),
+  setState: (newState) => set(newState, true),
+}));
+
+loadState().then((data) => {
+  if (data) {
+    useStore.getState().setState(data);
+  }
+});
+
+useStore.subscribe((state) => {
+  const { inventory, isInventoryOpen } = state;
+  saveState({ inventory, isInventoryOpen });
+});

--- a/src/ui/inventory.js
+++ b/src/ui/inventory.js
@@ -1,0 +1,85 @@
+import { useStore } from '../state/store.js';
+
+export class InventoryUI {
+  constructor() {
+    this.container = document.createElement('div');
+    this.container.id = 'inventory';
+    this.container.style.display = 'none';
+    this.container.innerHTML = `<div class="grid"></div>`;
+    document.body.appendChild(this.container);
+
+    const style = document.createElement('style');
+    style.textContent = `
+      #inventory {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(0,0,0,0.8);
+        padding: 10px;
+        color: white;
+        z-index: 1000;
+      }
+      #inventory .grid {
+        display: grid;
+        grid-template-columns: repeat(5, 64px);
+        grid-auto-rows: 64px;
+        gap: 4px;
+      }
+      #inventory .slot {
+        width: 64px;
+        height: 64px;
+        border: 1px solid #555;
+        position: relative;
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #inventory .slot .count {
+        position: absolute;
+        right: 2px;
+        bottom: 2px;
+        background: rgba(0,0,0,0.6);
+        padding: 1px 3px;
+        font-size: 12px;
+      }
+    `;
+    document.head.appendChild(style);
+
+    this.grid = this.container.querySelector('.grid');
+
+    useStore.subscribe((state) => {
+      this.render(state.inventory);
+      this.container.style.display = state.isInventoryOpen ? 'block' : 'none';
+    });
+
+    window.addEventListener('keydown', (e) => {
+      if (e.code === 'Tab') {
+        e.preventDefault();
+        useStore.getState().toggleInventory();
+      }
+    });
+
+    // initial render
+    const state = useStore.getState();
+    this.render(state.inventory);
+    this.container.style.display = state.isInventoryOpen ? 'block' : 'none';
+  }
+
+  render(inventory) {
+    this.grid.innerHTML = '';
+    inventory.forEach((item) => {
+      const slot = document.createElement('div');
+      slot.className = 'slot';
+      slot.textContent = item.name || item.id;
+      if (item.count > 1) {
+        const count = document.createElement('div');
+        count.className = 'count';
+        count.textContent = item.count;
+        slot.appendChild(count);
+      }
+      this.grid.appendChild(slot);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add DOM-based inventory UI with Tab toggle and grid display
- manage game state in new Zustand store with stackable items
- persist inventory via IndexedDB with auto save/load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0f28d7bc83338ac348d3dfc5768c