### PR TITLE
Add basic plant manager and interactions

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { PlayerController } from '../player/playerController.js';
 import { SceneManager } from '../render/sceneManager.js';
 import { Physics } from '../physics/physics.js';
+import { PlantManager } from '../plants/plantManager.js';
 
 export class App {
   constructor(root) {
@@ -21,7 +22,8 @@ export class App {
 
     this.physics = new Physics();
     this.sceneManager = new SceneManager(this.scene, this.renderer);
-    this.player = new PlayerController(this.camera, this.renderer.domElement, this.physics);
+    this.plantManager = new PlantManager(this.scene);
+    this.player = new PlayerController(this.camera, this.renderer.domElement, this.physics, this.plantManager);
 
     window.addEventListener('resize', () => {
       this.camera.aspect = window.innerWidth / window.innerHeight;
@@ -37,6 +39,7 @@ export class App {
     const dt = Math.min(this.clock.getDelta(), 0.033);
     this.physics.step(dt);
     this.player.update(dt);
+    this.plantManager.update(dt);
     this.sceneManager.update(dt);
     this.renderer.render(this.scene, this.camera);
   }

--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -1,0 +1,91 @@
+import * as THREE from 'three';
+import species from './species.json' assert { type: 'json' };
+
+export class PlantManager {
+  constructor(scene) {
+    this.scene = scene;
+    this.species = species;
+    this.plants = [];
+    this.dryRate = 0.02;
+
+    // simple ground for raycasts
+    this.ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(20, 20),
+      new THREE.MeshStandardMaterial({ color: 0x228b22 })
+    );
+    this.ground.rotation.x = -Math.PI / 2;
+    this.scene.add(this.ground);
+  }
+
+  plantAt(position, speciesId) {
+    const spec = this.species[speciesId];
+    if (!spec) return null;
+    const mesh = this.createMesh(spec, 0);
+    mesh.position.copy(position);
+    this.scene.add(mesh);
+    const plant = {
+      speciesId,
+      species: spec,
+      mesh,
+      position: mesh.position,
+      stageIndex: 0,
+      growthPoints: 0,
+      hydration: spec.requirements.water
+    };
+    this.plants.push(plant);
+    return plant;
+  }
+
+  createMesh(spec, stageIndex) {
+    const size = 0.2 + stageIndex * 0.3;
+    const geom = new THREE.BoxGeometry(size, size, size);
+    const mat = new THREE.MeshStandardMaterial({ color: spec.color });
+    return new THREE.Mesh(geom, mat);
+  }
+
+  update(dt) {
+    for (const p of this.plants) {
+      this.tickPlant(p, dt);
+    }
+  }
+
+  tickPlant(p, dt) {
+    const spec = p.species;
+    const sun = 1; // placeholder full sunlight
+    const water = Math.min(1, p.hydration / spec.requirements.water);
+    const fert = 1; // fertility not modelled yet
+    const mult = Math.min(1, sun / spec.requirements.sunlight) * water * fert;
+    p.growthPoints += spec.growthRate * mult * dt;
+    p.hydration = Math.max(0, p.hydration - this.dryRate * dt);
+
+    const nextStage = spec.stages[p.stageIndex + 1];
+    if (nextStage && p.growthPoints >= nextStage.minGP) {
+      this.advanceStage(p);
+    }
+  }
+
+  advanceStage(p) {
+    p.stageIndex++;
+    this.scene.remove(p.mesh);
+    p.mesh = this.createMesh(p.species, p.stageIndex);
+    p.mesh.position.copy(p.position);
+    this.scene.add(p.mesh);
+  }
+
+  waterPlant(p, amount = 0.2) {
+    p.hydration = Math.min(p.species.requirements.water, p.hydration + amount);
+  }
+
+  harvestPlant(p) {
+    this.scene.remove(p.mesh);
+    this.plants = this.plants.filter(pl => pl !== p);
+  }
+
+  getMeshes() {
+    return this.plants.map(p => p.mesh);
+  }
+
+  getPlantByMesh(mesh) {
+    return this.plants.find(p => p.mesh === mesh);
+  }
+}

--- a/src/plants/species.json
+++ b/src/plants/species.json
@@ -1,0 +1,82 @@
+{
+  "daisy": {
+    "color": "#ffffff",
+    "requirements": { "sunlight": 0.5, "water": 0.4, "fertility": 0.3 },
+    "growthRate": 1,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 10 },
+      { "name": "harvest", "minGP": 20 }
+    ]
+  },
+  "tulip": {
+    "color": "#ff3366",
+    "requirements": { "sunlight": 0.6, "water": 0.5, "fertility": 0.4 },
+    "growthRate": 1.1,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 12 },
+      { "name": "harvest", "minGP": 24 }
+    ]
+  },
+  "lavender": {
+    "color": "#9966cc",
+    "requirements": { "sunlight": 0.7, "water": 0.3, "fertility": 0.4 },
+    "growthRate": 0.9,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 15 },
+      { "name": "harvest", "minGP": 30 }
+    ]
+  },
+  "sunflower": {
+    "color": "#ffcc00",
+    "requirements": { "sunlight": 0.9, "water": 0.6, "fertility": 0.5 },
+    "growthRate": 1.3,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 20 },
+      { "name": "harvest", "minGP": 40 }
+    ]
+  },
+  "fern": {
+    "color": "#33cc66",
+    "requirements": { "sunlight": 0.3, "water": 0.7, "fertility": 0.4 },
+    "growthRate": 0.8,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 10 },
+      { "name": "harvest", "minGP": 25 }
+    ]
+  },
+  "succulent": {
+    "color": "#99cc99",
+    "requirements": { "sunlight": 0.8, "water": 0.2, "fertility": 0.2 },
+    "growthRate": 0.7,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 14 },
+      { "name": "harvest", "minGP": 28 }
+    ]
+  },
+  "tomato": {
+    "color": "#cc3333",
+    "requirements": { "sunlight": 0.7, "water": 0.6, "fertility": 0.6 },
+    "growthRate": 1.2,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 18 },
+      { "name": "harvest", "minGP": 36 }
+    ]
+  },
+  "maple": {
+    "color": "#cc6600",
+    "requirements": { "sunlight": 0.5, "water": 0.5, "fertility": 0.5 },
+    "growthRate": 0.6,
+    "stages": [
+      { "name": "seedling", "minGP": 0 },
+      { "name": "growing", "minGP": 25 },
+      { "name": "harvest", "minGP": 50 }
+    ]
+  }
+}

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -1,10 +1,41 @@
+import * as THREE from 'three';
+
 export class PlayerController {
-  constructor(camera, domElement, physics) {
+  constructor(camera, domElement, physics, plantManager) {
     this.camera = camera;
     this.domElement = domElement;
     this.physics = physics;
+    this.plantManager = plantManager;
+
+    this.raycaster = new THREE.Raycaster();
+
+    window.addEventListener('keydown', (e) => {
+      if (e.code === 'KeyE') this.interact();
+    });
   }
+
   update(dt) {
-    // TODO: implement player movement and interaction
+    // TODO: implement player movement
+  }
+
+  interact() {
+    this.raycaster.setFromCamera(new THREE.Vector2(0, 0), this.camera);
+
+    const plantHits = this.raycaster.intersectObjects(this.plantManager.getMeshes());
+    if (plantHits.length > 0) {
+      const plant = this.plantManager.getPlantByMesh(plantHits[0].object);
+      if (plant.stageIndex >= plant.species.stages.length - 1) {
+        this.plantManager.harvestPlant(plant);
+      } else {
+        this.plantManager.waterPlant(plant);
+      }
+      return;
+    }
+
+    const groundHits = this.raycaster.intersectObject(this.plantManager.ground);
+    if (groundHits.length > 0) {
+      const position = groundHits[0].point;
+      this.plantManager.plantAt(position, 'daisy');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- define eight plant species with simple requirements and growth stages
- implement PlantManager for seeding, growth ticks, and stage transitions using placeholder meshes
- hook up player `E` interactions to plant, water, or harvest and update visuals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0f27b2188333a014f3619c52b79d