### PR TITLE
Refactor player controller initialization

### DIFF
--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -20,6 +20,12 @@ export class PlayerController {
     this.keys = {};
     this.jumpRequested = false;
 
+    this.plantManager = plantManager;
+    this.raycaster = new THREE.Raycaster();
+    window.addEventListener('keydown', (e) => {
+      if (e.code === 'KeyE') this.interact();
+    });
+
     // Setup pointer lock for mouse look
     this.domElement.addEventListener('click', () => {
       this.domElement.requestPointerLock();
@@ -107,17 +113,6 @@ export class PlayerController {
       this.body.position.y + (this.eyeHeight - this.radius),
       this.body.position.z
     );
-    this.plantManager = plantManager;
-
-    this.raycaster = new THREE.Raycaster();
-
-    window.addEventListener('keydown', (e) => {
-      if (e.code === 'KeyE') this.interact();
-    });
-  }
-
-  update(dt) {
-    // TODO: implement player movement
   }
 
   interact() {


### PR DESCRIPTION
## Summary
- move plant manager, raycaster, and interaction listener into the player controller constructor
- remove redundant update stub and centralize movement, sprint, jump, and camera syncing logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad12a5c2708333ace8eb8bbbba3d82