### PR TITLE
Pass physics object to SceneManager

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -24,7 +24,7 @@ export class App {
     this.camera.position.set(0, 1.6, 5);
 
     this.physics = new Physics();
-    this.sceneManager = new SceneManager(this.scene, this.renderer);
+    this.sceneManager = new SceneManager(this.scene, this.renderer, this.physics);
     this.plantManager = new PlantManager(this.scene);
     this.player = new PlayerController(this.camera, this.renderer.domElement, this.physics, this.plantManager);
     this.inventoryUI = new InventoryUI();

--- a/src/physics/physics.js
+++ b/src/physics/physics.js
@@ -1,4 +1,3 @@
-import * as CANNON from 'cannon-es';
 import { World, Vec3, Body, Plane } from 'cannon-es';
 
 // Simple physics wrapper around cannon-es. Uses a fixed 5 Hz tick and

--- a/src/render/sceneManager.js
+++ b/src/render/sceneManager.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import * as CANNON from 'cannon-es';
+import { Body, Plane, Box, Vec3 } from 'cannon-es';
 
 // Builds the world geometry and lights.
 export class SceneManager {
@@ -41,10 +41,12 @@ export class SceneManager {
     mesh.receiveShadow = true;
     this.scene.add(mesh);
 
-    const body = new CANNON.Body({ mass: 0 });
-    body.addShape(new CANNON.Plane());
-    body.quaternion.setFromEuler(-Math.PI / 2, 0, 0);
-    this.physics.world.addBody(body);
+    if (this.physics) {
+      const body = new Body({ mass: 0 });
+      body.addShape(new Plane());
+      body.quaternion.setFromEuler(-Math.PI / 2, 0, 0);
+      this.physics.world.addBody(body);
+    }
   }
 
   _initWalls() {
@@ -62,12 +64,14 @@ export class SceneManager {
       wall.receiveShadow = true;
       this.scene.add(wall);
 
-      const shape = new CANNON.Box(new CANNON.Vec3(30, height / 2, thickness / 2));
-      const body = new CANNON.Body({ mass: 0 });
-      body.addShape(shape);
-      body.position.set(x, height / 2, z);
-      body.quaternion.setFromEuler(0, rotY, 0);
-      this.physics.world.addBody(body);
+      if (this.physics) {
+        const shape = new Box(new Vec3(30, height / 2, thickness / 2));
+        const body = new Body({ mass: 0 });
+        body.addShape(shape);
+        body.position.set(x, height / 2, z);
+        body.quaternion.setFromEuler(0, rotY, 0);
+        this.physics.world.addBody(body);
+      }
     };
 
     createWall(0, -halfSize, 0); // back


### PR DESCRIPTION
## Summary
- Pass physics instance into SceneManager when app starts.
- Use named imports for Cannon shapes and guard physics usage inside SceneManager.
- Remove unused wildcard Cannon import in physics module.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad129c866c8333a6cd72cae1750ad8