### PR TITLE
Use shared ground mesh in PlantManager and PlayerController

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -25,8 +25,14 @@ export class App {
 
     this.physics = new Physics();
     this.sceneManager = new SceneManager(this.scene, this.renderer, this.physics);
-    this.plantManager = new PlantManager(this.scene);
-    this.player = new PlayerController(this.camera, this.renderer.domElement, this.physics, this.plantManager);
+    this.plantManager = new PlantManager(this.scene, this.sceneManager.ground);
+    this.player = new PlayerController(
+      this.camera,
+      this.renderer.domElement,
+      this.physics,
+      this.plantManager,
+      this.sceneManager.ground
+    );
     this.inventoryUI = new InventoryUI();
 
     window.addEventListener('resize', () => {

--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -2,19 +2,12 @@ import * as THREE from 'three';
 import species from './species.json' assert { type: 'json' };
 
 export class PlantManager {
-  constructor(scene) {
+  constructor(scene, ground) {
     this.scene = scene;
+    this.ground = ground;
     this.species = species;
     this.plants = [];
     this.dryRate = 0.02;
-
-    // simple ground for raycasts
-    this.ground = new THREE.Mesh(
-      new THREE.PlaneGeometry(20, 20),
-      new THREE.MeshStandardMaterial({ color: 0x228b22 })
-    );
-    this.ground.rotation.x = -Math.PI / 2;
-    this.scene.add(this.ground);
   }
 
   plantAt(position, speciesId) {

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -5,7 +5,7 @@ import * as CANNON from 'cannon-es';
 // pointer-lock mouse look. Integrates with the Physics wrapper.
 
 export class PlayerController {
-  constructor(camera, domElement, physics, plantManager) {
+  constructor(camera, domElement, physics, plantManager, ground) {
     this.camera = camera;
     this.domElement = domElement;
     this.physics = physics;
@@ -21,6 +21,7 @@ export class PlayerController {
     this.jumpRequested = false;
 
     this.plantManager = plantManager;
+    this.ground = ground;
     this.raycaster = new THREE.Raycaster();
     window.addEventListener('keydown', (e) => {
       if (e.code === 'KeyE') this.interact();
@@ -129,7 +130,7 @@ export class PlayerController {
       return;
     }
 
-    const groundHits = this.raycaster.intersectObject(this.plantManager.ground);
+    const groundHits = this.raycaster.intersectObject(this.ground);
     if (groundHits.length > 0) {
       const position = groundHits[0].point;
       this.plantManager.plantAt(position, 'daisy');

--- a/src/render/sceneManager.js
+++ b/src/render/sceneManager.js
@@ -40,6 +40,7 @@ export class SceneManager {
     mesh.rotation.x = -Math.PI / 2;
     mesh.receiveShadow = true;
     this.scene.add(mesh);
+    this.ground = mesh;
 
     if (this.physics) {
       const body = new Body({ mass: 0 });


### PR DESCRIPTION
## Summary
- Pass ground plane from SceneManager into PlantManager
- Expose ground mesh from SceneManager and use it in PlayerController raycasts
- Remove PlantManager's internal ground creation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad138f06608333946825baef129ac5