### PR TITLE
Implement seed inventory and harvesting rewards

### DIFF
--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import species from './species.json' assert { type: 'json' };
+import { useStore } from '../state/store.js';
 
 export class PlantManager {
   constructor(scene, ground) {
@@ -72,6 +73,9 @@ export class PlantManager {
   harvestPlant(p) {
     this.scene.remove(p.mesh);
     this.plants = this.plants.filter(pl => pl !== p);
+    const store = useStore.getState();
+    store.addItem({ id: `seed_${p.speciesId}`, type: 'seed', count: 2 });
+    store.addItem({ id: 'decor_token', type: 'decor', count: 1 });
   }
 
   getMeshes() {

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import * as CANNON from 'cannon-es';
+import { useStore } from '../state/store.js';
 
 // Basic first-person controller with WASD movement, jump, sprint and
 // pointer-lock mouse look. Integrates with the Physics wrapper.
@@ -133,7 +134,13 @@ export class PlayerController {
     const groundHits = this.raycaster.intersectObject(this.ground);
     if (groundHits.length > 0) {
       const position = groundHits[0].point;
-      this.plantManager.plantAt(position, 'daisy');
+      const seedId = 'seed_daisy';
+      const store = useStore.getState();
+      const hasSeed = store.inventory.find((i) => i.id === seedId && i.count > 0);
+      if (hasSeed) {
+        this.plantManager.plantAt(position, 'daisy');
+        store.removeItem(seedId, 1);
+      }
     }
   }
 }

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -2,7 +2,8 @@ import { create } from 'zustand';
 import { saveState, loadState } from './persistence.js';
 
 export const useStore = create((set, get) => ({
-  inventory: [],
+  // Start players with a few daisy seeds in their inventory
+  inventory: [{ id: 'seed_daisy', type: 'seed', count: 3 }],
   isInventoryOpen: false,
   addItem: (item) => {
     set((state) => {


### PR DESCRIPTION
## Summary
- Seed inventory initialized with starting daisy seeds
- Planting consumes seeds from inventory
- Harvesting grants seeds and decor tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad154d2b6483338222cbd6837d3249