### PR TITLE
Add sunlight calculations and plant growth modulation

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -25,7 +25,11 @@ export class App {
 
     this.physics = new Physics();
     this.sceneManager = new SceneManager(this.scene, this.renderer, this.physics);
-    this.plantManager = new PlantManager(this.scene, this.sceneManager.ground);
+    this.plantManager = new PlantManager(
+      this.scene,
+      this.sceneManager.ground,
+      this.sceneManager
+    );
     this.player = new PlayerController(
       this.camera,
       this.renderer.domElement,

--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -2,9 +2,10 @@ import * as THREE from 'three';
 import species from './species.json' assert { type: 'json' };
 
 export class PlantManager {
-  constructor(scene, ground) {
+  constructor(scene, ground, sceneManager) {
     this.scene = scene;
     this.ground = ground;
+    this.sceneManager = sceneManager;
     this.species = species;
     this.plants = [];
     this.dryRate = 0.02;
@@ -44,7 +45,7 @@ export class PlantManager {
 
   tickPlant(p, dt) {
     const spec = p.species;
-    const sun = 1; // placeholder full sunlight
+    const sun = this.sceneManager ? this.sceneManager.sunlightAt(p.position) : 1;
     const water = Math.min(1, p.hydration / spec.requirements.water);
     const fert = 1; // fertility not modelled yet
     const mult = Math.min(1, sun / spec.requirements.sunlight) * water * fert;


### PR DESCRIPTION
## Summary
- extend day-night cycle to 600 seconds and track sun intensity
- add `sunlightAt` for occlusion-based light queries
- drive plant growth with actual sunlight values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad154ec1208333bd97e38ce5a9e024