### PR TITLE
Persist plant data

### DIFF
--- a/src/state/persistence.js
+++ b/src/state/persistence.js
@@ -1,6 +1,7 @@
 const DB_NAME = 'game-db';
 const STORE_NAME = 'state';
-const KEY = 'game';
+const STATE_KEY = 'game';
+const PLANTS_KEY = 'plants';
 
 function openDB() {
   return new Promise((resolve, reject) => {
@@ -19,7 +20,7 @@ export async function saveState(state) {
     await new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       const store = tx.objectStore(STORE_NAME);
-      store.put(state, KEY);
+      store.put(state, STATE_KEY);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
@@ -35,7 +36,7 @@ export async function loadState() {
     const result = await new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
-      const req = store.get(KEY);
+      const req = store.get(STATE_KEY);
       req.onsuccess = () => resolve(req.result || null);
       req.onerror = () => reject(req.error);
     });
@@ -44,5 +45,39 @@ export async function loadState() {
   } catch (err) {
     console.error('Failed to load state', err);
     return null;
+  }
+}
+
+export async function savePlants(plants) {
+  try {
+    const db = await openDB();
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      store.put(plants, PLANTS_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch (err) {
+    console.error('Failed to save plants', err);
+  }
+}
+
+export async function loadPlants() {
+  try {
+    const db = await openDB();
+    const result = await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.get(PLANTS_KEY);
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    });
+    db.close();
+    return result;
+  } catch (err) {
+    console.error('Failed to load plants', err);
+    return [];
   }
 }


### PR DESCRIPTION
## Summary
- extend persistence layer with plant save/load helpers
- add plant manager change notifications
- load and periodically persist plants via App startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad154f93648333af713b9f8deacd5e