### PR TITLE
Add soil tile map and planting preview

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,6 +5,7 @@ import { SceneManager } from '../render/sceneManager.js';
 import { Physics } from '../physics/physics.js';
 import { PlantManager } from '../plants/plantManager.js';
 import { InventoryUI } from '../ui/inventory.js';
+import { Soil } from '../world/soil.js';
 
 export class App {
   constructor(root) {
@@ -25,13 +26,14 @@ export class App {
 
     this.physics = new Physics();
     this.sceneManager = new SceneManager(this.scene, this.renderer, this.physics);
-    this.plantManager = new PlantManager(this.scene, this.sceneManager.ground);
+    this.soil = new Soil(this.scene);
+    this.plantManager = new PlantManager(this.scene, this.soil);
     this.player = new PlayerController(
       this.camera,
       this.renderer.domElement,
       this.physics,
       this.plantManager,
-      this.sceneManager.ground
+      this.soil
     );
     this.inventoryUI = new InventoryUI();
 

--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -2,31 +2,61 @@ import * as THREE from 'three';
 import species from './species.json' assert { type: 'json' };
 
 export class PlantManager {
-  constructor(scene, ground) {
+  constructor(scene, soil) {
     this.scene = scene;
-    this.ground = ground;
+    this.soil = soil;
     this.species = species;
     this.plants = [];
     this.dryRate = 0.02;
+    this.preview = null;
+    this.previewTile = null;
   }
 
   plantAt(position, speciesId) {
     const spec = this.species[speciesId];
     if (!spec) return null;
-    const mesh = this.createMesh(spec, 0);
-    mesh.position.copy(position);
-    this.scene.add(mesh);
-    const plant = {
-      speciesId,
-      species: spec,
-      mesh,
-      position: mesh.position,
-      stageIndex: 0,
-      growthPoints: 0,
-      hydration: spec.requirements.water
-    };
-    this.plants.push(plant);
-    return plant;
+
+    const tile = this.soil.getTileAt(position);
+    if (!tile) return null;
+
+    const valid = tile.plantable && !tile.occupied;
+
+    // Setup preview mesh if needed
+    if (!this.preview) {
+      this.preview = this.createMesh(spec, 0);
+      this.preview.material = this.preview.material.clone();
+      this.preview.material.transparent = true;
+      this.preview.material.opacity = 0.5;
+      this.scene.add(this.preview);
+    }
+
+    this.preview.material.color.set(valid ? 0x00ff00 : 0xff0000);
+    this.preview.position.copy(tile.position);
+
+    if (this.previewTile === tile && valid) {
+      // Confirm placement
+      this.scene.remove(this.preview);
+      this.preview = null;
+      this.previewTile = null;
+      tile.occupied = true;
+      const mesh = this.createMesh(spec, 0);
+      mesh.position.copy(tile.position);
+      this.scene.add(mesh);
+      const plant = {
+        speciesId,
+        species: spec,
+        mesh,
+        position: mesh.position,
+        stageIndex: 0,
+        growthPoints: 0,
+        hydration: spec.requirements.water
+      };
+      this.plants.push(plant);
+      return plant;
+    } else {
+      this.previewTile = tile;
+      return null;
+    }
   }
 
   createMesh(spec, stageIndex) {

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -5,7 +5,7 @@ import * as CANNON from 'cannon-es';
 // pointer-lock mouse look. Integrates with the Physics wrapper.
 
 export class PlayerController {
-  constructor(camera, domElement, physics, plantManager, ground) {
+  constructor(camera, domElement, physics, plantManager, soil) {
     this.camera = camera;
     this.domElement = domElement;
     this.physics = physics;
@@ -21,7 +21,7 @@ export class PlayerController {
     this.jumpRequested = false;
 
     this.plantManager = plantManager;
-    this.ground = ground;
+    this.soil = soil;
     this.raycaster = new THREE.Raycaster();
     window.addEventListener('keydown', (e) => {
       if (e.code === 'KeyE') this.interact();
@@ -130,9 +130,9 @@ export class PlayerController {
       return;
     }
 
-    const groundHits = this.raycaster.intersectObject(this.ground);
-    if (groundHits.length > 0) {
-      const position = groundHits[0].point;
+    const soilHits = this.raycaster.intersectObjects(this.soil.getMeshes());
+    if (soilHits.length > 0) {
+      const position = soilHits[0].point;
       this.plantManager.plantAt(position, 'daisy');
     }
   }

--- a/src/world/soil.js
+++ b/src/world/soil.js
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+
+// Simple soil bed composed of a grid of tiles marking plantable areas.
+export class Soil {
+  constructor(scene, width = 10, depth = 10, tileSize = 1) {
+    this.scene = scene;
+    this.width = width;
+    this.depth = depth;
+    this.tileSize = tileSize;
+    this.tiles = [];
+    this.meshes = [];
+
+    const geom = new THREE.PlaneGeometry(tileSize, tileSize);
+    const mat = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
+
+    const halfW = (width * tileSize) / 2;
+    const halfD = (depth * tileSize) / 2;
+
+    for (let x = 0; x < width; x++) {
+      this.tiles[x] = [];
+      for (let z = 0; z < depth; z++) {
+        const mesh = new THREE.Mesh(geom, mat.clone());
+        mesh.rotation.x = -Math.PI / 2;
+        const posX = -halfW + x * tileSize + tileSize / 2;
+        const posZ = -halfD + z * tileSize + tileSize / 2;
+        mesh.position.set(posX, 0.01, posZ);
+        scene.add(mesh);
+
+        const tile = {
+          x,
+          z,
+          mesh,
+          plantable: true,
+          occupied: false,
+          position: mesh.position.clone(),
+        };
+        mesh.userData.tile = tile;
+        this.tiles[x][z] = tile;
+        this.meshes.push(mesh);
+      }
+    }
+  }
+
+  // Get all tile meshes for raycasting
+  getMeshes() {
+    return this.meshes;
+  }
+
+  // Find the tile under a given world position
+  getTileAt(position) {
+    const halfW = (this.width * this.tileSize) / 2;
+    const halfD = (this.depth * this.tileSize) / 2;
+    const xIndex = Math.floor((position.x + halfW) / this.tileSize);
+    const zIndex = Math.floor((position.z + halfD) / this.tileSize);
+    if (
+      xIndex < 0 ||
+      zIndex < 0 ||
+      xIndex >= this.width ||
+      zIndex >= this.depth
+    ) {
+      return null;
+    }
+    return this.tiles[xIndex][zIndex];
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce `Soil` grid defining plantable tiles
- raycast against soil beds for planting interactions
- validate tile occupancy and show colored preview before planting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad15451e8883339454a5dfcb1496a6