### PR TITLE
Add soil tile system and enforce planting rules

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -6,6 +6,7 @@ import { Physics } from '../physics/physics.js';
 import { PlantManager } from '../plants/plantManager.js';
 import { InventoryUI } from '../ui/inventory.js';
 import { savePlants, loadPlants } from '../state/persistence.js';
+import { SoilTiles } from '../render/soilTiles.js';
 
 export class App {
   constructor(root) {
@@ -27,17 +28,20 @@ export class App {
 
     this.physics = new Physics();
     this.sceneManager = new SceneManager(this.scene, this.renderer, this.physics);
+    this.soilTiles = new SoilTiles(this.scene);
     this.plantManager = new PlantManager(
       this.scene,
       this.sceneManager.ground,
-      this.sceneManager
+      this.sceneManager,
+      this.soilTiles
     );
     this.player = new PlayerController(
       this.camera,
       this.renderer.domElement,
       this.physics,
       this.plantManager,
-      this.sceneManager.ground
+      this.sceneManager.ground,
+      this.soilTiles
     );
     this.inventoryUI = new InventoryUI();
 
@@ -48,6 +52,7 @@ export class App {
     loadPlants().then(plants => {
       for (const data of plants) {
         const position = new THREE.Vector3(data.position.x, data.position.y, data.position.z);
+        this.soilTiles.toggleAt(position);
         const plant = this.plantManager.plantAt(position, data.speciesId);
         if (plant) {
           plant.stageIndex = data.stageIndex;

--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -3,10 +3,11 @@ import species from './species.json' assert { type: 'json' };
 import { useStore } from '../state/store.js';
 
 export class PlantManager {
-  constructor(scene, ground, sceneManager) {
+  constructor(scene, ground, sceneManager, soilTiles) {
     this.scene = scene;
     this.ground = ground;
     this.sceneManager = sceneManager;
+    this.soilTiles = soilTiles;
     this.species = species;
     this.plants = [];
     this.dryRate = 0.02;
@@ -16,8 +17,16 @@ export class PlantManager {
   plantAt(position, speciesId) {
     const spec = this.species[speciesId];
     if (!spec) return null;
+    if (!this.soilTiles?.isPlantable(position)) return null;
+    const clearance = spec.clearance ?? 0.5;
+    for (const p of this.plants) {
+      if (p.position.distanceTo(position) < clearance) {
+        return null;
+      }
+    }
+    const tilePos = this.soilTiles.getTileCenter(position);
     const mesh = this.createMesh(spec, 0);
-    mesh.position.copy(position);
+    mesh.position.copy(tilePos);
     this.scene.add(mesh);
     const plant = {
       speciesId,

--- a/src/plants/species.json
+++ b/src/plants/species.json
@@ -3,6 +3,7 @@
     "color": "#ffffff",
     "requirements": { "sunlight": 0.5, "water": 0.4, "fertility": 0.3 },
     "growthRate": 1,
+    "clearance": 0.5,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 10 },
@@ -13,6 +14,7 @@
     "color": "#ff3366",
     "requirements": { "sunlight": 0.6, "water": 0.5, "fertility": 0.4 },
     "growthRate": 1.1,
+    "clearance": 0.5,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 12 },
@@ -23,6 +25,7 @@
     "color": "#9966cc",
     "requirements": { "sunlight": 0.7, "water": 0.3, "fertility": 0.4 },
     "growthRate": 0.9,
+    "clearance": 0.6,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 15 },
@@ -33,6 +36,7 @@
     "color": "#ffcc00",
     "requirements": { "sunlight": 0.9, "water": 0.6, "fertility": 0.5 },
     "growthRate": 1.3,
+    "clearance": 0.8,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 20 },
@@ -43,6 +47,7 @@
     "color": "#33cc66",
     "requirements": { "sunlight": 0.3, "water": 0.7, "fertility": 0.4 },
     "growthRate": 0.8,
+    "clearance": 0.6,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 10 },
@@ -53,6 +58,7 @@
     "color": "#99cc99",
     "requirements": { "sunlight": 0.8, "water": 0.2, "fertility": 0.2 },
     "growthRate": 0.7,
+    "clearance": 0.5,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 14 },
@@ -63,6 +69,7 @@
     "color": "#cc3333",
     "requirements": { "sunlight": 0.7, "water": 0.6, "fertility": 0.6 },
     "growthRate": 1.2,
+    "clearance": 0.7,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 18 },
@@ -73,6 +80,7 @@
     "color": "#cc6600",
     "requirements": { "sunlight": 0.5, "water": 0.5, "fertility": 0.5 },
     "growthRate": 0.6,
+    "clearance": 1,
     "stages": [
       { "name": "seedling", "minGP": 0 },
       { "name": "growing", "minGP": 25 },

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -6,7 +6,7 @@ import { useStore } from '../state/store.js';
 // pointer-lock mouse look. Integrates with the Physics wrapper.
 
 export class PlayerController {
-  constructor(camera, domElement, physics, plantManager, ground) {
+  constructor(camera, domElement, physics, plantManager, ground, soilTiles) {
     this.camera = camera;
     this.domElement = domElement;
     this.physics = physics;
@@ -23,6 +23,7 @@ export class PlayerController {
 
     this.plantManager = plantManager;
     this.ground = ground;
+    this.soilTiles = soilTiles;
     this.raycaster = new THREE.Raycaster();
     this.currentTool = 'shovel';
     this.water = 1;
@@ -175,12 +176,18 @@ export class PlayerController {
     const groundHits = this.raycaster.intersectObject(this.ground);
     if (groundHits.length > 0) {
       const position = groundHits[0].point;
-      const seedId = 'seed_daisy';
-      const store = useStore.getState();
-      const hasSeed = store.inventory.find((i) => i.id === seedId && i.count > 0);
-      if (hasSeed) {
-        this.plantManager.plantAt(position, 'daisy');
-        store.removeItem(seedId, 1);
+      if (this.soilTiles.isPlantable(position)) {
+        const seedId = 'seed_daisy';
+        const store = useStore.getState();
+        const hasSeed = store.inventory.find((i) => i.id === seedId && i.count > 0);
+        if (hasSeed) {
+          const planted = this.plantManager.plantAt(position, 'daisy');
+          if (planted) {
+            store.removeItem(seedId, 1);
+          }
+        }
+      } else {
+        this.soilTiles.toggleAt(position);
       }
     }
   }

--- a/src/render/soilTiles.js
+++ b/src/render/soilTiles.js
@@ -1,0 +1,53 @@
+import * as THREE from 'three';
+
+export class SoilTiles {
+  constructor(scene, size = 1) {
+    this.scene = scene;
+    this.size = size;
+    this.tiles = new Map();
+  }
+
+  _key(ix, iz) {
+    return `${ix},${iz}`;
+  }
+
+  _posToIndices(pos) {
+    return [Math.floor(pos.x / this.size), Math.floor(pos.z / this.size)];
+  }
+
+  _indicesToCenter(ix, iz) {
+    return new THREE.Vector3((ix + 0.5) * this.size, 0, (iz + 0.5) * this.size);
+  }
+
+  toggleAt(pos) {
+    const [ix, iz] = this._posToIndices(pos);
+    const key = this._key(ix, iz);
+    let tile = this.tiles.get(key);
+    if (!tile) {
+      const geom = new THREE.PlaneGeometry(this.size, this.size);
+      const mat = new THREE.MeshStandardMaterial({ color: 0x553322, side: THREE.DoubleSide });
+      const mesh = new THREE.Mesh(geom, mat);
+      mesh.rotation.x = -Math.PI / 2;
+      const center = this._indicesToCenter(ix, iz);
+      mesh.position.set(center.x, 0.01, center.z);
+      mesh.visible = false;
+      this.scene.add(mesh);
+      tile = { mesh, plantable: false };
+      this.tiles.set(key, tile);
+    }
+    tile.plantable = !tile.plantable;
+    tile.mesh.visible = tile.plantable;
+    return tile.plantable;
+  }
+
+  isPlantable(pos) {
+    const [ix, iz] = this._posToIndices(pos);
+    const tile = this.tiles.get(this._key(ix, iz));
+    return tile ? tile.plantable : false;
+  }
+
+  getTileCenter(pos) {
+    const [ix, iz] = this._posToIndices(pos);
+    return this._indicesToCenter(ix, iz);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce SoilTiles manager to toggle plantable ground visuals
- gate planting on tile availability and species clearance radii
- allow shovel tool to toggle soil tiles or plant on prepared soil

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1869d4d48333aa608d116e17fa84