### PR TITLE
Add disposal for player controller

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -87,6 +87,8 @@ export class App {
       this.renderer.setSize(window.innerWidth, window.innerHeight);
     });
 
+    window.addEventListener('beforeunload', () => this.dispose());
+
     this.loop();
   }
 
@@ -102,5 +104,9 @@ export class App {
       this.player.update(dt);
     }
     this.renderer.render(this.scene, this.camera);
+  }
+
+  dispose() {
+    this.player.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- track bound event listeners and store unsubscribe callbacks in player controller
- add dispose method to clean up listeners and subscriptions
- call controller dispose on app shutdown

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d2c20108333a37a305a0d6785e9