### PR TITLE
Refactor shovel interaction

### DIFF
--- a/src/plants/plantManager.js
+++ b/src/plants/plantManager.js
@@ -18,6 +18,16 @@ export class PlantManager {
     return `${Math.floor(pos.x)}_${Math.floor(pos.z)}`;
   }
 
+  toggleSoil(position) {
+    const key = this.tileKey(position);
+    if (this.soil.has(key)) {
+      this.soil.delete(key);
+    } else {
+      this.soil.set(key, 1);
+    }
+    this.notifyChange();
+  }
+
   plantAt(position, speciesId) {
     const spec = this.species[speciesId];
     if (!spec) return null;
@@ -113,6 +123,12 @@ export class PlantManager {
     const store = useStore.getState();
     store.addItem({ id: `seed_${p.speciesId}`, type: 'seed', count: 2 });
     store.addItem({ id: 'decor_token', type: 'decor', count: 1 });
+  }
+
+  removePlant(p) {
+    this.scene.remove(p.mesh);
+    this.plants = this.plants.filter(pl => pl !== p);
+    this.notifyChange();
   }
 
   getMeshes() {

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -6,7 +6,7 @@ import { useStore } from '../state/store.js';
 // pointer-lock mouse look. Integrates with the Physics wrapper.
 
 export class PlayerController {
-  constructor(camera, domElement, physics, plantManager, ground) {
+  constructor(camera, domElement, physics, plantManager, ground, decorManager = null) {
     this.camera = camera;
     this.domElement = domElement;
     this.physics = physics;
@@ -29,6 +29,7 @@ export class PlayerController {
 
     this.plantManager = plantManager;
     this.ground = ground;
+    this.decorManager = decorManager;
     this.raycaster = new THREE.Raycaster();
     this.currentTool = 'shovel';
     this.water = 1;
@@ -322,25 +323,28 @@ export class PlayerController {
 
   useShovel() {
     this.raycaster.setFromCamera(new THREE.Vector2(0, 0), this.camera);
+    if (this.decorManager && this.decorManager.getMeshes) {
+      const decorHits = this.raycaster.intersectObjects(this.decorManager.getMeshes());
+      if (decorHits.length > 0) {
+        decorHits[0].object.rotation.y += Math.PI / 2;
+        this.playTick();
+        return;
+      }
+    }
     const plantHits = this.raycaster.intersectObjects(this.plantManager.getMeshes());
     if (plantHits.length > 0) {
       const plant = this.plantManager.getPlantByMesh(plantHits[0].object);
-      plant.mesh.rotation.y += Math.PI / 2;
-      this.playTick();
+      if (plant.stageIndex === 0) {
+        this.plantManager.removePlant(plant);
+        this.playTick();
+      }
       return;
     }
     const groundHits = this.raycaster.intersectObject(this.ground);
-    if (groundHits.length > 0 && this.activeSeedId) {
+    if (groundHits.length > 0) {
       const position = groundHits[0].point;
-      const seedId = this.activeSeedId;
-      const store = useStore.getState();
-      const hasSeed = store.inventory.find((i) => i.id === seedId && i.count > 0);
-      if (hasSeed) {
-        const speciesId = seedId.replace('seed_', '');
-        this.plantManager.plantAt(position, speciesId);
-        store.removeItem(seedId, 1);
-        this.playTick();
-      }
+      this.plantManager.toggleSoil(position);
+      this.playTick();
     }
   }
 


### PR DESCRIPTION
## Summary
- Allow shovel to toggle soil prep and uproot seedlings instead of planting seeds
- Add optional decor rotation support and remove seed usage during soil prep
- Extend plant manager with soil toggling and plant removal helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d2f2aec833395bc79803fc97ba6