### PR TITLE
Ensure save interval cleanup on unload

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -15,6 +15,7 @@ export class App {
     this.clock = new THREE.Clock();
     this.store = createStore(() => ({}));
     this.plantsDirty = false;
+    this.saveInterval = null;
   }
 
   start() {
@@ -66,7 +67,7 @@ export class App {
       }
     });
 
-    setInterval(() => {
+    this.saveInterval = setInterval(() => {
       if (this.plantsDirty) {
         const data = this.plantManager.plants.map(p => ({
           speciesId: p.speciesId,
@@ -80,6 +81,8 @@ export class App {
         this.plantsDirty = false;
       }
     }, 3000);
+
+    window.addEventListener('beforeunload', () => this.stop());
 
     window.addEventListener('resize', () => {
       this.camera.aspect = window.innerWidth / window.innerHeight;
@@ -102,5 +105,12 @@ export class App {
       this.player.update(dt);
     }
     this.renderer.render(this.scene, this.camera);
+  }
+
+  stop() {
+    if (this.saveInterval) {
+      clearInterval(this.saveInterval);
+      this.saveInterval = null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Track autosave interval so it can be cleared
- Add stop method to clear interval
- Call stop during page unload to prevent background saves

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d2e343c8333b194c03120107c15