### PR TITLE
Preserve default store fields when loading

### DIFF
--- a/src/state/store.js
+++ b/src/state/store.js
@@ -54,12 +54,12 @@ export const useStore = create((set, get) => ({
   setVolume: (volume) => set({ volume }),
   setMouseSensitivity: (mouseSensitivity) => set({ mouseSensitivity }),
   setBobEnabled: (bobEnabled) => set({ bobEnabled }),
-  setState: (newState) => set(newState, true),
+  setState: (newState) => set(newState),
 }));
 
 loadState().then((data) => {
   if (data) {
-    useStore.getState().setState(data);
+    useStore.setState(data);
   }
 });
 


### PR DESCRIPTION
## Summary
- prevent store overwrites by merging new state in `setState`
- merge loaded state using `useStore.setState` so default values and actions persist

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad26b7ffc483339f767702a07a62db