### PR TITLE
Merge default key bindings with loaded state

### DIFF
--- a/src/state/store.js
+++ b/src/state/store.js
@@ -59,7 +59,11 @@ export const useStore = create((set, get) => ({
 
 loadState().then((data) => {
   if (data) {
-    useStore.setState(data);
+    const mergedBindings = {
+      ...useStore.getState().keyBindings,
+      ...(data.keyBindings || {}),
+    };
+    useStore.setState({ ...data, keyBindings: mergedBindings });
   }
   useStore.setState({ isPaused: false });
 });


### PR DESCRIPTION
## Summary
- merge persisted key bindings with defaults on load to ensure new actions are available

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3ccaed408333a8c249da2a34837f